### PR TITLE
Fix the validate* function signatures in tests and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ class TestInput(graphene.InputObjectType):
     person = graphene.InputField(PersonalDataInput)
 
     @staticmethod
-    def validate_email(email, info, **input):
+    def validate_email(email, info, **input_args):
         if "@" not in email:
             raise InvalidEmailFormat
         return email.strip(" ")
 
     @staticmethod
-    def validate_numbers(numbers, info, **input):
+    def validate_numbers(numbers, info, **input_args):
         if len(numbers) < 2:
             raise LengthNotInRange(min=2)
         for n in numbers:
@@ -44,7 +44,7 @@ class TestInput(graphene.InputObjectType):
         return numbers
 
     @staticmethod
-    def validate(input):
+    def validate(input, info):
         if input.get("people") and input.get("email"):
             first_person_name_and_age = (
                 f"{input['people'][0]['the_name']}{input['people'][0]['the_age']}"
@@ -106,8 +106,8 @@ class TestInput(graphene.InputObjectType):
     second_field = graphene.String()
 
     @staticmethod
-    def validate_first_field(first_field, info, **input):
-        second_field = input.get("second_field")
+    def validate_first_field(first_field, info, **input_args):
+        second_field = input_args.get("second_field")
         if second_field != "desired value":
             raise InvalidSecondField
         if info.context.user.role != "admin":

--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -27,7 +27,7 @@ def validated(cls):
         name = graphene.String()
 
         @staticmethod
-        def validate_name(name):
+        def validate_name(name, info, **input_args):
             if not 300 < len(name) < 3:
                 raise LengthNotInRange(min=1, max=300)
             return name
@@ -37,7 +37,7 @@ def validated(cls):
         people = graphene.List(PeopleInput)
 
         @staticmethod
-        def validate_email(email):
+        def validate_email(email, info, **input_args):
             if "@" not in email:
                 raise InvalidEmailFormat
             return email

--- a/tests.py
+++ b/tests.py
@@ -27,19 +27,19 @@ class PersonalDataInput(graphene.InputObjectType):
     the_age = graphene.Int()
 
     @staticmethod
-    def validate_the_name(name):
+    def validate_the_name(name, info, **input_args):
         if len(name) == 0:
             raise EmptyString
         return name
 
     @staticmethod
-    def validate_the_age(age):
+    def validate_the_age(age, info, **input_args):
         if age < 0:
             raise NegativeValue
         return age
 
     @staticmethod
-    def validate(inpt):
+    def validate(inpt, info):
         if inpt["the_name"] == str(inpt["the_age"]):
             raise NameEqualsAge(path=["name"])
         return inpt
@@ -52,13 +52,13 @@ class TestInput(graphene.InputObjectType):
     person = graphene.InputField(PersonalDataInput)
 
     @staticmethod
-    def validate_email(email):
+    def validate_email(email, info, **input_args):
         if "@" not in email:
             raise InvalidEmailFormat
         return email.strip(" ")
 
     @staticmethod
-    def validate_numbers(numbers):
+    def validate_numbers(numbers, info, **input_args):
         if len(numbers) < 2:
             raise LengthNotInRange(min=2)
         for n in numbers:
@@ -67,7 +67,7 @@ class TestInput(graphene.InputObjectType):
         return numbers
 
     @staticmethod
-    def validate(inpt):
+    def validate(inpt, info):
         if inpt.get("people") and inpt.get("email"):
             first_person_name_and_age = (
                 f"{inpt['people'][0]['the_name']}{inpt['people'][0]['the_age']}"


### PR DESCRIPTION
The tests had wrong signatures in the `validate*` functions. All the `validate*` functions take an `info` as a second argument. The
`validate_<field_name>` functions additionally take some keyword arguments, thus receiving the whole mutation input.

The documentation was a bit incorrect as well, so fixed it.

Started calling the keyword arguments received by `validate_<field_name>` as `input_args`, hopefully better describing that they mean the mutation input arguments.