### PR TITLE
Changes and improvements to make this library usable for us

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ class TestInput(graphene.InputObjectType):
     person = graphene.InputField(PersonalDataInput)
 
     @staticmethod
-    def validate_email(email, info, **input):
+    def validate_email(email, info, **input_args):
         if "@" not in email:
             raise InvalidEmailFormat
         return email.strip(" ")
 
     @staticmethod
-    def validate_numbers(numbers, info, **input):
+    def validate_numbers(numbers, info, **input_args):
         if len(numbers) < 2:
             raise LengthNotInRange(min=2)
         for n in numbers:
@@ -44,7 +44,7 @@ class TestInput(graphene.InputObjectType):
         return numbers
 
     @staticmethod
-    def validate(input):
+    def validate(input, info):
         if input.get("people") and input.get("email"):
             first_person_name_and_age = (
                 f"{input['people'][0]['the_name']}{input['people'][0]['the_age']}"
@@ -106,8 +106,8 @@ class TestInput(graphene.InputObjectType):
     second_field = graphene.String()
 
     @staticmethod
-    def validate_first_field(first_field, info, **input):
-        second_field = input.get("second_field")
+    def validate_first_field(first_field, info, **input_args):
+        second_field = input_args.get("second_field")
         if second_field != "desired value":
             raise InvalidSecondField
         if info.context.user.role != "admin":

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ The GraphQL Python ecosystem (i.e. `graphene`) lacks a proper way of validating 
 
 This library provides a class decorator `@validated`, for mutations, that allows for field level and input level validation similarly to [DRF](https://www.django-rest-framework.org/) serializers' `validate` methods. To validate a field you'll need to declare a static method named `validate_{field_name}`. Input wide validation (e.g. for fields that depend on other fields) can be performed in the `validate` method. `validate` will only be called if all field level validation methods succeed.
 
-Field level errors also provide a `path` field that helps the client determine which slice of input is invalid, useful for rich forms and field highlighting on the UI. To indicate an invalid value the corresponding validation method should raise an instance of a subclass of `ValidationError`. Validation methods also allow to manipulate the value on the fly (for example to minimize DB queries by swapping an ID for the corresponding object) which will then replace the corresponding value in the main input (to be used in `validate` and the mutation itself).
+It also supports recursive validation so that you can use nested `InputField`s and validation will be performed all the way down to the scalars.
 
-Custom errors can be defined (e.g. `NotInRange` with `min` and `max`) to inform the clients of potential constraints on the input itself (via an optional `meta` property). It also supports recursive validation so that you can use nested `InputField`s and validation will be performed all the way down to the scalars.
+To indicate an invalid value the corresponding validation method should raise an instance of a subclass of `ValidationError`. Validation methods also allow to manipulate the value on the fly (for example to minimize DB queries by swapping an ID for the corresponding object) which will then replace the corresponding value in the main input (to be used in `validate` and the mutation itself).
+
+A `ValidationError` subclass can report one or more validation errors. Its `error_details` attribute must be an iterable of dictionaries, providing the details for the validation errors. The error detail mappings can contain any members, but as a convention `code` member is encouraged to be included.
+
+For field level errors the error details will be amended with a `path` member that helps the client determine which slice of input is invalid, useful for rich forms and field highlighting on the UI.
+
+A `SingleValidationError` class is provided for validation errors that only contain a single error detail. This class also supports a `meta` error detail property, to inform the clients of potential constraints on the input itself.
 
 Note that verbose messages aren't supported because I strongly believe those should be handled on the client (together with localization).
 

--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -1,8 +1,6 @@
 import functools
 
-from graphql import GraphQLError
-
-from .errors import ValidationError
+from .errors import ValidationError, ValidationGraphQLError
 from .utils import _get_path, _unpack_input_tree, _unwrap_validator
 
 
@@ -17,7 +15,8 @@ def validated(cls):
     whole input tree.
 
     The `validate_{field_name}` methods must raise a ValidationError instance
-    in case of invalid input. This will be converted into a proper GraphQLError.
+    in case of invalid input. The ValidationErrors are collected and any errors
+    are reported by raising a dedicated GraphQLError subclass, ValidationGraphQLError.
 
     Nested validators and lists are supported.
 
@@ -140,7 +139,7 @@ def validated(cls):
                         errors += list(ve.error_details)
 
             if errors:
-                raise GraphQLError(
+                raise ValidationGraphQLError(
                     message="ValidationError",
                     extensions={"validationErrors": errors},
                 )

--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -27,7 +27,7 @@ def validated(cls):
         name = graphene.String()
 
         @staticmethod
-        def validate_name(name):
+        def validate_name(name, info, **input_args):
             if not 300 < len(name) < 3:
                 raise LengthNotInRange(min=1, max=300)
             return name
@@ -37,7 +37,7 @@ def validated(cls):
         people = graphene.List(PeopleInput)
 
         @staticmethod
-        def validate_email(email):
+        def validate_email(email, info, **input_args):
             if "@" not in email:
                 raise InvalidEmailFormat
             return email

--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -101,7 +101,6 @@ def validated(cls):
             # Run field level validation logic
             for ftv in fields_to_validate:
                 name, value, validator, _parent, _idx = ftv
-                path = _get_path(ftv)
                 try:
                     new_value = getattr(
                         validator,
@@ -110,12 +109,14 @@ def validated(cls):
                     )(value, info, **kwargs)
                     # If validator changed the value we need to update it in the input tree
                     if new_value != value:
+                        path = _get_path(ftv, False)
                         # Grab a ref to the field to change by following the path in the input tree
                         field = functools.reduce(
                             lambda obj, k: obj[k] if k else obj, path[:-1], input_tree
                         )
                         field[name] = new_value
                 except ValidationError as ve:
+                    path = _get_path(ftv)
                     errors.append({"code": str(ve), "path": path, "meta": ve.meta})
 
             # Don't run subtree level validation if one or more fields are invalid

--- a/graphene_validator/errors.py
+++ b/graphene_validator/errors.py
@@ -6,7 +6,7 @@ Ideally specific validation errors should be carefully named and be self explana
 """
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterable, Mapping
 
 
 class ValidationError(ValueError):
@@ -31,6 +31,10 @@ class ValidationError(ValueError):
     @property
     def code(self):
         return self.__class__.__name__
+
+    @property
+    def error_details(self) -> Iterable[Mapping[str, Any]]:
+        return [{"code": self.code, "path": getattr(self, "path", None), "meta": self.meta}]
 
 
 class EmptyString(ValidationError):

--- a/graphene_validator/errors.py
+++ b/graphene_validator/errors.py
@@ -24,10 +24,6 @@ class ValidationError(ValueError):
 
 
 class SingleValidationError(ValidationError):
-    def __init__(self, *args, path=[], **kwargs):
-        super().__init__(*args, **kwargs)
-        self.path = path
-
     @property
     def meta(self):
         """
@@ -40,7 +36,7 @@ class SingleValidationError(ValidationError):
 
     @property
     def error_details(self) -> Iterable[Mapping[str, Any]]:
-        return [{"code": self.code, "path": getattr(self, "path", None), "meta": self.meta}]
+        return [{"code": self.code, "meta": self.meta}]
 
 
 class EmptyString(SingleValidationError):

--- a/graphene_validator/errors.py
+++ b/graphene_validator/errors.py
@@ -8,6 +8,8 @@ Ideally specific validation errors should be carefully named and be self explana
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
+from graphql import GraphQLError
+
 
 class ValidationError(ValueError):
     """
@@ -62,4 +64,8 @@ class NotInRange(SingleValidationError):
 
 
 class LengthNotInRange(NotInRange):
+    pass
+
+
+class ValidationGraphQLError(GraphQLError):
     pass

--- a/graphene_validator/errors.py
+++ b/graphene_validator/errors.py
@@ -15,12 +15,18 @@ class ValidationError(ValueError):
     in a mutation's input.
     """
 
+    def __str__(self):
+        return self.__class__.__name__
+
+    @property
+    def error_details(self) -> Iterable[Mapping[str, Any]]:
+        return []
+
+
+class SingleValidationError(ValidationError):
     def __init__(self, *args, path=[], **kwargs):
         super().__init__(*args, **kwargs)
         self.path = path
-
-    def __str__(self):
-        return self.__class__.__name__
 
     @property
     def meta(self):
@@ -37,20 +43,20 @@ class ValidationError(ValueError):
         return [{"code": self.code, "path": getattr(self, "path", None), "meta": self.meta}]
 
 
-class EmptyString(ValidationError):
+class EmptyString(SingleValidationError):
     pass
 
 
-class InvalidEmailFormat(ValidationError):
+class InvalidEmailFormat(SingleValidationError):
     pass
 
 
-class NegativeValue(ValidationError):
+class NegativeValue(SingleValidationError):
     pass
 
 
 @dataclass
-class NotInRange(ValidationError):
+class NotInRange(SingleValidationError):
     min: Any = None
     max: Any = None
 

--- a/graphene_validator/schema.py
+++ b/graphene_validator/schema.py
@@ -35,7 +35,7 @@ try:
                             if issubclass(error_class, ValidationError):
                                 error = error_class()
                                 errors.add((error.code,))
-                        except TypeError:
+                        except (TypeError, AttributeError):
                             # Not a real class...
                             continue
             return ({"code": error[0]} for error in errors)

--- a/graphene_validator/utils.py
+++ b/graphene_validator/utils.py
@@ -7,15 +7,16 @@ def _to_camel_case(name):
     )
 
 
-def _get_path(field):
+def _get_path(field, camel_case=True):
     """
     Reconstruct the path to the given field, including list indices.
     """
+    name_transform = _to_camel_case if camel_case else lambda text: text
     name, _value, _validator, parent, idx = field
-    path = [idx, _to_camel_case(name)] if idx is not None else [_to_camel_case(name)]
+    path = [idx, name_transform(name)] if idx is not None else [name_transform(name)]
     while parent:
         pname, _pvalue, _pvalidator, parent, pidx = parent
-        path.insert(0, _to_camel_case(pname))
+        path.insert(0, name_transform(pname))
         if pidx:
             path.insert(0, pidx)
     return path

--- a/tests.py
+++ b/tests.py
@@ -14,7 +14,15 @@ from graphene_validator.errors import (
 
 
 class NameEqualsAge(SingleValidationError):
-    pass
+    def __init__(self, path):
+        self.path = path
+
+    @property
+    def error_details(self):
+        details = super().error_details
+        for detail in details:
+            detail["path"] = self.path
+        return details
 
 
 class NameAndAgeInEmail(SingleValidationError):

--- a/tests.py
+++ b/tests.py
@@ -7,17 +7,17 @@ from graphene_validator.errors import (
     LengthNotInRange,
     NegativeValue,
     NotInRange,
-    ValidationError,
+    SingleValidationError,
 )
 
 # Some dummy errors
 
 
-class NameEqualsAge(ValidationError):
+class NameEqualsAge(SingleValidationError):
     pass
 
 
-class NameAndAgeInEmail(ValidationError):
+class NameAndAgeInEmail(SingleValidationError):
     pass
 
 

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,7 @@
 import graphene
 
-from .graphene_validator.decorators import validated
-from .graphene_validator.errors import (
+from graphene_validator.decorators import validated
+from graphene_validator.errors import (
     EmptyString,
     InvalidEmailFormat,
     LengthNotInRange,

--- a/tests.py
+++ b/tests.py
@@ -77,15 +77,19 @@ class TestInput(graphene.InputObjectType):
         return inpt
 
 
+class TestMutationOutput(graphene.ObjectType):
+    email = graphene.String()
+
+
 @validated
 class TestMutation(graphene.Mutation):
     class Arguments:
         _inpt = graphene.Argument(TestInput, name="input")
 
-    result = graphene.String()
+    Output = TestMutationOutput
 
     def mutate(self, _info, _inpt):
-        return TestMutation(result=_inpt.get("email"))
+        return TestMutationOutput(email=_inpt.get("email"))
 
 
 class Mutations(graphene.ObjectType):
@@ -101,7 +105,7 @@ class TestValidation:
         request_string="""
         mutation Test($input: TestInput!) {
             testMutation(input: $input) {
-                result
+                email
             }
         }"""
     )
@@ -142,7 +146,7 @@ class TestValidation:
         )
         result = schema.execute(**request)
         assert not result.errors
-        assert result.data["testMutation"]["result"] == "a0@b.c"
+        assert result.data["testMutation"]["email"] == "a0@b.c"
 
     def test_transform(self):
         request = dict(
@@ -156,7 +160,7 @@ class TestValidation:
         )
         result = schema.execute(**request)
         assert not result.errors
-        assert result.data["testMutation"]["result"] == "a0@b.c"
+        assert result.data["testMutation"]["email"] == "a0@b.c"
 
     def test_root_validate(self):
         request = dict(

--- a/tests.py
+++ b/tests.py
@@ -27,19 +27,19 @@ class PersonalDataInput(graphene.InputObjectType):
     the_age = graphene.Int()
 
     @staticmethod
-    def validate_the_name(name):
+    def validate_the_name(name, info, **input_args):
         if len(name) == 0:
             raise EmptyString
         return name
 
     @staticmethod
-    def validate_the_age(age):
+    def validate_the_age(age, info, **input_args):
         if age < 0:
             raise NegativeValue
         return age
 
     @staticmethod
-    def validate(inpt):
+    def validate(inpt, info):
         if inpt["the_name"] == str(inpt["the_age"]):
             raise NameEqualsAge(path=["name"])
         return inpt
@@ -52,13 +52,13 @@ class TestInput(graphene.InputObjectType):
     person = graphene.InputField(PersonalDataInput)
 
     @staticmethod
-    def validate_email(email):
+    def validate_email(email, info, **input_args):
         if "@" not in email:
             raise InvalidEmailFormat
         return email.strip(" ")
 
     @staticmethod
-    def validate_numbers(numbers):
+    def validate_numbers(numbers, info, **input_args):
         if len(numbers) < 2:
             raise LengthNotInRange(min=2)
         for n in numbers:
@@ -67,7 +67,7 @@ class TestInput(graphene.InputObjectType):
         return numbers
 
     @staticmethod
-    def validate(inpt):
+    def validate(inpt, info):
         if inpt.get("people") and inpt.get("email"):
             first_person_name_and_age = (
                 f"{inpt['people'][0]['the_name']}{inpt['people'][0]['the_age']}"


### PR DESCRIPTION
Contains a series of smallish, not strictly related, changes to make this library suitable for our use.

First few commits just make the library workable, by making it possible to run tests and by fixing some method signatures. A bug is also fixed.

The improvements change the base `ValidationError` in a way that it can report multiple validation errors at a time. This is analogous to how Django `ValidationError` works which also can report multiple errors (actually it can report a directed graph of `ValidationErrors`, but that's needlessly complex to support).

Finally, instead of raising a pure `graphql.GraphQLError` in case of validation errors, a dedicated sub class (called `ValidationGraphQLError`) is raised, so that it can be identified to be related to validation in further request processing.