### PR TITLE
Null input handling

### DIFF
--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -128,13 +128,11 @@ def validated(cls):
                 for stv in subtrees_to_validate:
                     value, validator = stv
                     try:
-                        input_tree.update(
-                            getattr(
-                                validator,
-                                "validate",
-                                lambda values, info, **kwargs: values,
-                            )(value, info)
-                        )
+                        getattr(
+                            validator,
+                            "validate",
+                            lambda values, info, **kwargs: values,
+                        )(value, info)
                     except ValidationError as ve:
                         errors += list(ve.error_details)
 

--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -83,7 +83,7 @@ def validated(cls):
     """
 
     class Wrapper(cls):
-        def mutate(self, info, **kwargs):  # pylint: disable=too-many-locals
+        def mutate(parent, info, **kwargs):  # pylint: disable=too-many-locals
             errors = []
             # Assume only a single input tree is given as kwarg
             input_key, input_tree = list(kwargs.items())[0]
@@ -143,7 +143,8 @@ def validated(cls):
                     message="ValidationError",
                     extensions={"validationErrors": errors},
                 )
-            return cls.mutate(self, info, **kwargs)
+
+            return cls.mutate(parent, info, **kwargs)
 
     Wrapper._meta.__dict__["name"] = cls._meta.name
     Wrapper._meta.__dict__["description"] = cls._meta.description

--- a/graphene_validator/decorators.py
+++ b/graphene_validator/decorators.py
@@ -4,6 +4,64 @@ from .errors import ValidationError, ValidationGraphQLError
 from .utils import _get_path, _unpack_input_tree, _unwrap_validator
 
 
+def _do_validation(info, input_tree, input_arg, **kwargs):
+    errors = []
+
+    root_validator = _unwrap_validator(
+        getattr(input_arg, "get_type", lambda: input_arg.type)()
+    )
+    # Run a BFS on the input tree, flattening everything to a list of fields to validate
+    # and a list of subtrees to validate as a whole (for codependent fields)
+    fields_to_validate, subtrees_to_validate = _unpack_input_tree(
+        input_tree, root_validator
+    )
+
+    # Run field level validation logic
+    for ftv in fields_to_validate:
+        name, value, validator, _parent, _idx = ftv
+        try:
+            new_value = getattr(
+                validator,
+                f"validate_{name}",
+                lambda value, info, **kwargs: value,
+            )(value, info, **kwargs)
+            # If validator changed the value we need to update it in the input tree
+            if new_value != value:
+                path = _get_path(ftv, False)
+                # Grab a ref to the field to change by following the path in the input tree
+                field = functools.reduce(
+                    lambda obj, k: obj[k] if k else obj, path[:-1], input_tree
+                )
+                field[name] = new_value
+        except ValidationError as ve:
+            # Insert the field's path into the error details
+            common_detail = {"path": _get_path(ftv)}
+            for error_detail in ve.error_details:
+                error_detail.update(common_detail)
+                errors.append(error_detail)
+
+    # Don't run subtree level validation if one or more fields are invalid
+    if not errors:
+        # Run validation logic for the input subtrees
+        subtrees_to_validate.append((input_tree, root_validator))
+        for stv in subtrees_to_validate:
+            value, validator = stv
+            try:
+                getattr(
+                    validator,
+                    "validate",
+                    lambda values, info, **kwargs: values,
+                )(value, info)
+            except ValidationError as ve:
+                errors += list(ve.error_details)
+
+    if errors:
+        raise ValidationGraphQLError(
+            message="ValidationError",
+            extensions={"validationErrors": errors},
+        )
+
+
 def validated(cls):
     """
     A class decorator to validate mutation input based on its input fields.
@@ -84,63 +142,11 @@ def validated(cls):
 
     class Wrapper(cls):
         def mutate(parent, info, **kwargs):  # pylint: disable=too-many-locals
-            errors = []
-            # Assume only a single input tree is given as kwarg
-            input_key, input_tree = list(kwargs.items())[0]
-            input_arg = getattr(cls.Arguments, input_key)
-            root_validator = _unwrap_validator(
-                getattr(input_arg, "get_type", lambda: input_arg.type)()
-            )
-            # Run a BFS on the input tree, flattening everything to a list of fields to validate
-            # and a list of subtrees to validate as a whole (for codependent fields)
-            fields_to_validate, subtrees_to_validate = _unpack_input_tree(
-                input_tree, root_validator
-            )
-
-            # Run field level validation logic
-            for ftv in fields_to_validate:
-                name, value, validator, _parent, _idx = ftv
-                try:
-                    new_value = getattr(
-                        validator,
-                        f"validate_{name}",
-                        lambda value, info, **kwargs: value,
-                    )(value, info, **kwargs)
-                    # If validator changed the value we need to update it in the input tree
-                    if new_value != value:
-                        path = _get_path(ftv, False)
-                        # Grab a ref to the field to change by following the path in the input tree
-                        field = functools.reduce(
-                            lambda obj, k: obj[k] if k else obj, path[:-1], input_tree
-                        )
-                        field[name] = new_value
-                except ValidationError as ve:
-                    # Insert the field's path into the error details
-                    common_detail = {"path": _get_path(ftv)}
-                    for error_detail in ve.error_details:
-                        error_detail.update(common_detail)
-                        errors.append(error_detail)
-
-            # Don't run subtree level validation if one or more fields are invalid
-            if not errors:
-                # Run validation logic for the input subtrees
-                subtrees_to_validate.append((input_tree, root_validator))
-                for stv in subtrees_to_validate:
-                    value, validator = stv
-                    try:
-                        getattr(
-                            validator,
-                            "validate",
-                            lambda values, info, **kwargs: values,
-                        )(value, info)
-                    except ValidationError as ve:
-                        errors += list(ve.error_details)
-
-            if errors:
-                raise ValidationGraphQLError(
-                    message="ValidationError",
-                    extensions={"validationErrors": errors},
-                )
+            if kwargs:
+                # Assume only a single input tree is given as kwarg
+                input_key, input_tree = list(kwargs.items())[0]
+                input_arg = getattr(cls.Arguments, input_key)
+                _do_validation(info, input_tree, input_arg, **kwargs)
 
             return cls.mutate(parent, info, **kwargs)
 

--- a/graphene_validator/utils.py
+++ b/graphene_validator/utils.py
@@ -88,11 +88,8 @@ def _unpack_input_tree(input_tree, validator_cls):
                 # List of complex types, unpack
                 inner_validator = _unwrap_validator(field_type)
                 for idx, item in enumerate(value):
-                    subtrees_to_validate.append((item, inner_validator))
-                    fields_to_unpack.extend(
-                        (name, value, inner_validator, current, idx)
-                        for name, value in item.items()
-                    )
+                    add_subtree_to_validate(item, inner_validator)
+                    add_fields_to_unpack(item, inner_validator, current, idx)
         else:
             # Scalar type, we can mark for validation!
             fields_to_validate.append((name, value, validator, parent, idx))

--- a/tests.py
+++ b/tests.py
@@ -33,6 +33,7 @@ class PersonalDataInput(graphene.InputObjectType):
     # Check camelCasing too
     the_name = graphene.String()
     the_age = graphene.Int()
+    email = graphene.String()
 
     @staticmethod
     def validate_the_name(name, info, **input_args):
@@ -48,7 +49,7 @@ class PersonalDataInput(graphene.InputObjectType):
 
     @staticmethod
     def validate(inpt, info):
-        if inpt["the_name"] == str(inpt["the_age"]):
+        if inpt.get("the_name") == str(inpt.get("the_age")):
             raise NameEqualsAge(path=["name"])
         return inpt
 
@@ -182,6 +183,20 @@ class TestValidation:
         assert not result.errors
         assert result.data["testMutation"]["email"] == "a0@b.c"
         assert result.data["testMutation"]["thePerson"]["theName"] == "a"
+
+    def test_sub_trees_are_independent(self):
+        request = dict(
+            **TestValidation.REQUEST_TEMPLATE,
+            variable_values={
+                "input": {
+                    "email": "top.level@email",
+                    "thePerson": {"email": "sub.tree@email"},
+                }
+            },
+        )
+        result = schema.execute(**request)
+        assert not result.errors
+        assert result.data["testMutation"]["email"] == "top.level@email"
 
     def test_root_validate(self):
         request = dict(

--- a/tests.py
+++ b/tests.py
@@ -260,3 +260,15 @@ class TestValidation:
         assert validation_errors[0]["code"] == NotInRange.__name__
         assert validation_errors[0]["meta"]["min"] == 0
         assert validation_errors[0]["meta"]["max"] == 9
+
+    def test_handling_inner_null_input_object(self):
+        request = dict(
+            **TestValidation.REQUEST_TEMPLATE,
+            variable_values={
+                "input": {
+                    "thePerson": None,
+                }
+            },
+        )
+        result = schema.execute(**request)
+        assert not result.errors

--- a/tests.py
+++ b/tests.py
@@ -285,3 +285,11 @@ class TestValidation:
         )
         result = schema.execute(**request)
         assert not result.errors
+
+    def test_handling_null_input_object_in_a_list(self):
+        request = dict(
+            **TestValidation.REQUEST_TEMPLATE,
+            variable_values={"input": {"people": [None]}},
+        )
+        result = schema.execute(**request)
+        assert not result.errors

--- a/tests.py
+++ b/tests.py
@@ -103,7 +103,10 @@ class TestMutation(graphene.Mutation):
 
     Output = TestMutationOutput
 
-    def mutate(self, _info, _inpt):
+    def mutate(self, _info, _inpt=None):
+        if _inpt is None:
+            _inpt = {}
+
         return TestMutationOutput(
             email=_inpt.get("email"),
             the_person=_inpt.get("the_person"),
@@ -121,7 +124,7 @@ class TestValidation:
 
     REQUEST_TEMPLATE = dict(
         request_string="""
-        mutation Test($input: TestInput!) {
+        mutation Test($input: TestInput) {
             testMutation(input: $input) {
                 email
                 thePerson {
@@ -260,6 +263,16 @@ class TestValidation:
         assert validation_errors[0]["code"] == NotInRange.__name__
         assert validation_errors[0]["meta"]["min"] == 0
         assert validation_errors[0]["meta"]["max"] == 9
+
+    def test_handling_top_level_null_input_object(self):
+        request = dict(
+            **TestValidation.REQUEST_TEMPLATE,
+            variable_values={
+                "input": None,
+            },
+        )
+        result = schema.execute(**request)
+        assert not result.errors
 
     def test_handling_inner_null_input_object(self):
         request = dict(


### PR DESCRIPTION
Input objects in GraphQL can be set to `null` (unless the schema forbids it). The library didn't handle `null` objects at all. Now it does.

Also fixes a bug where the input tree gets messed up.